### PR TITLE
Moved herbalism kit outside of gaming sets

### DIFF
--- a/05.equipment.md
+++ b/05.equipment.md
@@ -495,10 +495,10 @@ A tool helps you to do something you couldn't otherwise do, such as craft or rep
 | ~ Woodcarver's tools      | 1 gp  | 5 lb.  |
 | Disguise kit              | 25 gp | 3 lb.  |
 | Forgery kit               | 15 gp | 5 lb.  |
+| Herbalism kit             | 5 gp  | 3 lb.  |
 | *Gaming set*              |       |        |
 | ~ Dice set                | 1 sp  | -      |
 | ~ Playing card set        | 5 sp  | -      |
-| ~ Herbalism kit           | 5 gp  | 3 lb.  |
 | *Musical instrument*      |       |        |
 | ~ Bagpipes                | 30 gp | 6 lb.  |
 | ~ Drum                    | 6 gp  | 3 lb.  |

--- a/05.equipment.md
+++ b/05.equipment.md
@@ -674,9 +674,6 @@ The Food, Drink, and Lodging table gives prices for individual food items and a 
 | *Ale*                  |       |
 | ~ Gallon               | 2 sp  |
 | ~ Mug                  | 4 cp  |
-| ~ Banquet (per person) | 10 gp |
-| ~ Bread, loaf          | 2 cp  |
-| ~ Cheese, hunk         | 1 sp  |
 | *Inn stay (per day)*   |       |
 | ~ Squalid              | 7 cp  |
 | ~ Poor                 | 1 sp  |
@@ -692,6 +689,9 @@ The Food, Drink, and Lodging table gives prices for individual food items and a 
 | ~ Wealthy              | 8 sp  |
 | ~ Aristocratic         | 2 gp  |
 | ~ Meat, chunk          | 3 sp  |
+| ~ Banquet (per person) | 10 gp |
+| ~ Bread, loaf          | 2 cp  |
+| ~ Cheese, hunk         | 1 sp  |
 | *Wine*                 |       |
 | ~ Common (pitcher)     | 2 sp  |
 | ~ Fine (bottle)        | 10 gp |


### PR DESCRIPTION
When going over the tables i noticed that herbalism kit was in the gaming set section. I suspect this isn't intended.